### PR TITLE
Multi wheel support

### DIFF
--- a/app/src/main/java/evil/spin/IWheelSerializer.java
+++ b/app/src/main/java/evil/spin/IWheelSerializer.java
@@ -24,7 +24,7 @@ public interface IWheelSerializer {
     List<Wheel> getWheelsFromJsonArray(JSONArray wheelsJsonArray) throws JSONException;
 
     @NonNull
-    Wheel getWheelFromJson(JSONObject wheelJson) throws JSONException;
+    Wheel getWheelFromJson(String wheelJson) throws JSONException;
 
     String[] toStringArray(JSONArray array);
 }

--- a/app/src/main/java/evil/spin/IWheelSerializer.java
+++ b/app/src/main/java/evil/spin/IWheelSerializer.java
@@ -1,0 +1,30 @@
+package evil.spin;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface IWheelSerializer {
+    String SerializeWheels(Collection<Wheel> wheels) throws JSONException;
+
+    void SaveWheelsToSharedPreferences(Collection<Wheel> wheels, SharedPreferences preferences) throws JSONException;
+
+    Collection<Wheel> LoadWheelsFromSharedPreferences(SharedPreferences preferences) throws JSONException;
+
+    Collection<Wheel> DeserializeWheels(String json) throws JSONException;
+
+    @NonNull
+    List<Wheel> getWheelsFromJsonArray(JSONArray wheelsJsonArray) throws JSONException;
+
+    @NonNull
+    Wheel getWheelFromJson(JSONObject wheelJson) throws JSONException;
+
+    String[] toStringArray(JSONArray array);
+}

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -9,18 +9,26 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.view.MenuItem;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.widget.Spinner;
+import android.widget.ArrayAdapter;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AlertDialog;
 import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.preference.PreferenceManager;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 
@@ -32,7 +40,8 @@ public class MainActivity extends AppCompatActivity {
     private Button settingsButton;
     private TextView titleBar;
     private ConstraintLayout mainLayout;
-    private Spinner wheelDropdown;
+    public DrawerLayout drawerLayout;
+    public ActionBarDrawerToggle actionBarDrawerToggle;
     private List<String> options = new ArrayList<>();
     private SharedPreferences sharedPreferences;
     private boolean wheelIsSpinning = false;
@@ -64,21 +73,37 @@ public class MainActivity extends AppCompatActivity {
         updateTitle();
         updateBackground();
         checkAnimationsEnabled();
-        prepareWheelDropdown();
 
+        prepareWheelMenu();
     }
-    private void prepareWheelDropdown(){
-        //get the spinner from the xml.
-        wheelDropdown = findViewById(R.id.spinner1);
-        //create a list of items for the spinner.
-        String[] items = new String[]{"1", "2", "three"};
-        //create an adapter to describe how the items are displayed, adapters are used in several places in android.
-        //There are multiple variations of this, but this is the basic variant.
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, items);
-        //set the spinners adapter to the previously created one.
-        wheelDropdown.setAdapter(adapter);
+
+    private void prepareWheelMenu() {
+        // drawer layout instance to toggle the menu icon to open
+        // drawer and back button to close drawer
+        drawerLayout = findViewById(R.id.my_drawer_layout);
+        actionBarDrawerToggle = new ActionBarDrawerToggle(this, drawerLayout, R.string.nav_open, R.string.nav_close);
+
+        // pass the Open and Close toggle for the drawer layout listener
+        // to toggle the button
+        drawerLayout.addDrawerListener(actionBarDrawerToggle);
+        actionBarDrawerToggle.syncState();
+
+        // to make the Navigation drawer icon always appear on the action bar
+        //Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
     }
-    
+    // override the onOptionsItemSelected()
+    // function to implement
+    // the item click listener callback
+    // to open and close the navigation
+    // drawer when the icon is clicked
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+
+        if (actionBarDrawerToggle.onOptionsItemSelected(item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
     private void checkAnimationsEnabled() {
         boolean animationsEnabled = Settings.Global.getFloat(getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1) != 0;
         if (!animationsEnabled) {

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -15,8 +15,6 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
-import android.widget.Spinner;
-import android.widget.ArrayAdapter;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -25,10 +23,14 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.preference.PreferenceManager;
+
+import org.json.JSONException;
+
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 
@@ -43,6 +45,8 @@ public class MainActivity extends AppCompatActivity {
     public DrawerLayout drawerLayout;
     public ActionBarDrawerToggle actionBarDrawerToggle;
     private List<String> options = new ArrayList<>();
+    private Collection<Wheel> Wheels = new ArrayList<Wheel>();
+    private IWheelSerializer wheelSerializer = new WheelSerializer();
     private SharedPreferences sharedPreferences;
     private boolean wheelIsSpinning = false;
 
@@ -75,6 +79,12 @@ public class MainActivity extends AppCompatActivity {
         checkAnimationsEnabled();
 
         prepareWheelMenu();
+        saveWheels();
+        try {
+            loadWheels();
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void prepareWheelMenu() {
@@ -238,5 +248,24 @@ public class MainActivity extends AppCompatActivity {
         Set<String> savedOptions = sharedPreferences.getStringSet("wheel_options", new HashSet<>());
         options = new ArrayList<>(savedOptions);
         wheelView.setOptions(options);
+    }
+    private void saveWheels(){
+
+        List<String> fakeoptions =  Arrays.asList("a","b");
+        Wheel wheel = new Wheel("Hello",fakeoptions);
+        Wheels.add(wheel);
+        wheel.Name="ni";
+        Wheels.add(wheel);
+        String json=wheel.Serialize();
+        try {
+            wheelSerializer.SaveWheelsToSharedPreferences(Wheels, sharedPreferences);
+
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    private void loadWheels() throws JSONException {
+        List<Wheel> loadedWheels=new ArrayList<>();
+        loadedWheels = (List<Wheel>) wheelSerializer.LoadWheelsFromSharedPreferences(sharedPreferences);
     }
 }

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -53,7 +53,6 @@ public class MainActivity extends AppCompatActivity {
     private ActionBarDrawerToggle actionBarDrawerToggle;
     private NavigationView navigationView;
     private Menu wheelMenu;
-    public androidx.appcompat.widget.Toolbar toolbar;
     private List<String> options = new ArrayList<>();
     private Collection<Wheel> Wheels = new ArrayList<Wheel>();
     private IWheelSerializer wheelSerializer = new WheelSerializer();
@@ -79,15 +78,17 @@ public class MainActivity extends AppCompatActivity {
         navigationView = findViewById(R.id.navigationView);
         wheelMenu = navigationView.getMenu();
 
-        toolbar = findViewById(R.id.toolbar);
-        this.setSupportActionBar(toolbar);
 
         actionBarDrawerToggle = new ActionBarDrawerToggle(this, mainLayout, R.string.nav_open, R.string.nav_close);
         mainLayout.addDrawerListener(actionBarDrawerToggle);
         actionBarDrawerToggle.syncState();
 
         // Enable the home button to show the drawer toggle
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setHomeButtonEnabled(true);
+        }
+
 
 
         addOptionButton.setOnClickListener(v -> addOption());
@@ -126,7 +127,16 @@ public class MainActivity extends AppCompatActivity {
         // Clean menu from previous wheels
         wheelMenu.clear();
         FakeWheels(); // TODO remove after testing
-        MenuItem.OnMenuItemClickListener menuItemClicked = new MenuItem.OnMenuItemClickListener() {
+        // Create a separate method for the menu item click listener
+        MenuItem.OnMenuItemClickListener menuItemClicked = createMenuItemClickListener();
+
+        for (Wheel wheel : Wheels) {
+            wheelMenu.add(wheel.Name).setOnMenuItemClickListener(menuItemClicked);
+        }
+
+    }
+    private MenuItem.OnMenuItemClickListener createMenuItemClickListener() {
+        return new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(@NonNull MenuItem menuItem) {
                 // Handle menu item click here
@@ -134,29 +144,14 @@ public class MainActivity extends AppCompatActivity {
                 return true;
             }
         };
-        for (Wheel wheel : Wheels) {
-            wheelMenu.add(wheel.Name).setOnMenuItemClickListener(menuItemClicked);
-        }
-        //mainLayout.setAct
-        // drawer layout instance to toggle the menu icon to open
-        // drawer and back button to close drawer
-//        drawerLayout = findViewById(R.id.activity_main);
-//        actionBarDrawerToggle = new ActionBarDrawerToggle(this, drawerLayout, R.string.nav_open, R.string.nav_close);
-//
-//        // pass the Open and Close toggle for the drawer layout listener
-//        // to toggle the button
-//        drawerLayout.addDrawerListener(actionBarDrawerToggle);
-//        actionBarDrawerToggle.syncState();
-
-        // to make the Navigation drawer icon always appear on the action bar
-        //getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
-    // override the onOptionsItemSelected()
-    // function to implement
-    // the item click listener callback
-    // to open and close the navigation
-    // drawer when the icon is clicked
-
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (actionBarDrawerToggle.onOptionsItemSelected(item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
     private void checkAnimationsEnabled() {
         boolean animationsEnabled = Settings.Global.getFloat(getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1) != 0;
         if (!animationsEnabled) {

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -32,6 +32,7 @@ public class MainActivity extends AppCompatActivity {
     private Button settingsButton;
     private TextView titleBar;
     private ConstraintLayout mainLayout;
+    private Spinner wheelDropdown;
     private List<String> options = new ArrayList<>();
     private SharedPreferences sharedPreferences;
     private boolean wheelIsSpinning = false;
@@ -63,8 +64,21 @@ public class MainActivity extends AppCompatActivity {
         updateTitle();
         updateBackground();
         checkAnimationsEnabled();
+        prepareWheelDropdown();
 
     }
+    private void prepareWheelDropdown(){
+        //get the spinner from the xml.
+        wheelDropdown = findViewById(R.id.spinner1);
+        //create a list of items for the spinner.
+        String[] items = new String[]{"1", "2", "three"};
+        //create an adapter to describe how the items are displayed, adapters are used in several places in android.
+        //There are multiple variations of this, but this is the basic variant.
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, items);
+        //set the spinners adapter to the previously created one.
+        wheelDropdown.setAdapter(adapter);
+    }
+    
     private void checkAnimationsEnabled() {
         boolean animationsEnabled = Settings.Global.getFloat(getContentResolver(), Settings.Global.ANIMATOR_DURATION_SCALE, 1) != 0;
         if (!animationsEnabled) {

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -15,7 +15,6 @@ import android.view.MenuItem;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -147,7 +146,6 @@ public class MainActivity extends AppCompatActivity {
     private void prepareWheelMenu() {
         // Clean menu from previous wheels
         wheelMenu.clear();
-       // FakeWheels(); // TODO remove after testing
         // Create a separate method for the menu item click listener
         MenuItem.OnMenuItemClickListener menuItemClicked = createMenuItemClickListener();
         List<Wheel> wheels=wheelDB.getWheels();
@@ -351,15 +349,6 @@ public class MainActivity extends AppCompatActivity {
         Toast.makeText(MainActivity.this,"Wheels saved",Toast.LENGTH_SHORT).show();
     }
 
-    private void FakeWheels() throws JSONException {
-        List<String> fakeoptions =  Arrays.asList("a","b","c");
-        List<String> fakeoptions2 =  Arrays.asList("aa","ba","ca");
-        wheelDB.AddWheelWithNewId("Hi",fakeoptions);
-        wheelDB.AddWheelWithNewId("No",fakeoptions2);
-
-        String json=wheelSerializer.SerializeWheels(wheelDB.getWheels());
-    }
-
     private void loadWheels() throws JSONException {
         List<Wheel> loadedWheels = (List<Wheel>) wheelSerializer.LoadWheelsFromSharedPreferences(sharedPreferences);
         wheelDB.setWheels(loadedWheels);
@@ -417,7 +406,7 @@ public class MainActivity extends AppCompatActivity {
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        // Todo think of a way of handling when no wheel is selected.
+        // Add new wheel as current wheel. This is how you ensure wheel is always present
         addWheel();
 
         // Update menu view

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -4,13 +4,12 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.provider.Settings;
-import android.util.Log;
+import android.text.InputType;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.inputmethod.InputMethodManager;
@@ -18,15 +17,11 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
-import android.widget.Toolbar;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.view.menu.ActionMenuItem;
-import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.preference.PreferenceManager;
 
@@ -36,15 +31,10 @@ import org.json.JSONException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import kotlin.NotImplementedError;
 
 public class MainActivity extends AppCompatActivity {
     private WheelView wheelView;
@@ -55,16 +45,16 @@ public class MainActivity extends AppCompatActivity {
     private Button saveButton;
     private Button addWheelButton;
     private Button deleteWheelButton;
-    private TextView titleBar;
+    private EditText titleBar;
     private DrawerLayout mainLayout;
     private DrawerLayout drawerLayout;
     private ActionBarDrawerToggle actionBarDrawerToggle;
     private NavigationView navigationView;
     private Menu wheelMenu;
     private List<String> options = new ArrayList<>();
-    private List<Wheel> Wheels = new ArrayList<Wheel>();
     private Wheel CurrentWheel;
     private final IWheelSerializer wheelSerializer = new WheelSerializer();
+    public WheelDB wheelDB = new WheelDB();
     private SharedPreferences sharedPreferences;
     private boolean wheelIsSpinning = false;
 
@@ -94,12 +84,7 @@ public class MainActivity extends AppCompatActivity {
         }
         prepareWheelMenu();
 
-        if (Wheels.isEmpty())
-            addWheel();
-        else
-            CurrentWheel = Wheels.iterator().next();
-
-        loadOptions(CurrentWheel);
+        LoadCurrentWheel();
 
         addOptionButton.setOnClickListener(v -> addOption());
         spinButton.setOnClickListener(v -> spinWheel());
@@ -107,9 +92,16 @@ public class MainActivity extends AppCompatActivity {
         RainbowBorderButtonDrawable rainbowDrawable = new RainbowBorderButtonDrawable(this);
         spinButton.setBackground(rainbowDrawable);
         updateWheelAppearance();
-        updateTitle(CurrentWheel);
         updateBackground();
         checkAnimationsEnabled();
+    }
+
+    private void LoadCurrentWheel() {
+        if (wheelDB.IsEmpty())
+            addWheel();
+        else
+            CurrentWheel = wheelDB.GetFirst();
+        updateWheel(CurrentWheel);
     }
 
     private void setUpSettingsButtons() {
@@ -117,7 +109,13 @@ public class MainActivity extends AppCompatActivity {
         deleteWheelButton = findViewById(R.id.btn_delete);
         addWheelButton = findViewById(R.id.btn_add_wheel);
 
-        saveButton.setOnClickListener(v->saveWheels());
+        saveButton.setOnClickListener(v-> {
+            try {
+                saveWheels();
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+        });
         deleteWheelButton.setOnClickListener(v->deleteWheel());
         addWheelButton.setOnClickListener(v->addWheel());
     }
@@ -152,54 +150,45 @@ public class MainActivity extends AppCompatActivity {
        // FakeWheels(); // TODO remove after testing
         // Create a separate method for the menu item click listener
         MenuItem.OnMenuItemClickListener menuItemClicked = createMenuItemClickListener();
-
-        for (Wheel wheel : Wheels) {
-            wheelMenu.add(wheel.Name).setOnMenuItemClickListener(menuItemClicked);
+        List<Wheel> wheels=wheelDB.getWheels();
+        for (Wheel wheel : wheels) {
+            wheelMenu.add(Menu.NONE, wheel.Id,Menu.NONE,wheel.Id+": "+ wheel.Name).setOnMenuItemClickListener(menuItemClicked);
+            addMenuSeparator(wheelMenu);
         }
 
+        // Update navigation view
+        navigationView.invalidate();
     }
     private MenuItem.OnMenuItemClickListener createMenuItemClickListener() {
-        return new MenuItem.OnMenuItemClickListener() {
-            @Override
-            public boolean onMenuItemClick(@NonNull MenuItem menuItem) {
-                // Handle menu item click here
-                String wheelName = (String) menuItem.getTitle();
-                Toast.makeText(MainActivity.this, wheelName + " clicked", Toast.LENGTH_SHORT).show();
-                try {
-                    CurrentWheel = findWheelByName(Wheels,(String) wheelName);
-                    loadOptions(CurrentWheel);
-                    updateTitle(CurrentWheel);
-                    // Do something with the found wheel
-                    Toast.makeText(MainActivity.this, "Found wheel: " + CurrentWheel.Name, Toast.LENGTH_SHORT).show();
+        return menuItem -> {
+            // Handle menu item click here
+            String wheelName = (String) menuItem.getTitle();
+            int wheelId = menuItem.getItemId();
 
-                } catch (Exception e) {
-                    // Handle the exception
-                    Toast.makeText(MainActivity.this, e.getMessage(), Toast.LENGTH_SHORT).show();
-                    return true;
-                }
+            Toast.makeText(MainActivity.this, wheelName + " clicked", Toast.LENGTH_SHORT).show();
 
+            try {
+                CurrentWheel = wheelDB.getWheelById(wheelId);
+                loadOptions(CurrentWheel);
+                updateTitle(CurrentWheel);
+                // Do something with the found wheel
+                Toast.makeText(MainActivity.this, "Found wheel: " + CurrentWheel.Name, Toast.LENGTH_SHORT).show();
+
+                drawerLayout.closeDrawers();
                 return true;
+
+            } catch (Exception e) {
+                // Handle the exception
+                Toast.makeText(MainActivity.this, e.getMessage(), Toast.LENGTH_SHORT).show();
+                return false;
             }
+
         };
     }
 
-
-    // Method to find a wheel by name
-    public Wheel findWheelByName(List<Wheel> wheels, String name) throws Exception {
-        // Filter wheels with the matching name
-        List<Wheel> matchingWheels = wheels.parallelStream()
-                .filter(wheel -> wheel.Name.equals(name))
-                .collect(Collectors.toList());
-
-        // Throw exception if no matching wheels or more than one matching wheel is found
-        if (matchingWheels.isEmpty()) {
-            throw new Exception("No wheel found with the name: " + name);
-        } else if (matchingWheels.size() > 1) {
-            throw new Exception("Multiple wheels found with the name: " + name);
-        }
-
-        // Return the single matching wheel
-        return matchingWheels.get(0);
+    private void addMenuSeparator(Menu menu) {
+        // Add a separator (divider) to the menu
+        menu.add(Menu.NONE, Menu.NONE, Menu.NONE, "").setEnabled(false);
     }
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
@@ -259,7 +248,6 @@ public class MainActivity extends AppCompatActivity {
             CurrentWheel.Options.add(option);
             wheelView.setOptions((List<String>) CurrentWheel.Options);
             optionInput.setText("");
-            saveOptions();
         }
     }
     private void clearEditTextFocus() {
@@ -270,7 +258,7 @@ public class MainActivity extends AppCompatActivity {
     }
     private void spinWheel() {
         clearEditTextFocus();
-        if (options.isEmpty()) {
+        if (CurrentWheel.Options.isEmpty()) {
             Toast.makeText(this, "Please add options before spinning", Toast.LENGTH_SHORT).show();
             return;
         }
@@ -335,12 +323,6 @@ public class MainActivity extends AppCompatActivity {
         wheelView.setColorPalette(colorPalette);
     }
 
-    private void saveOptions() {
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putStringSet("wheel_options", new HashSet<>(options));
-        editor.apply();
-    }
-
     private void loadOptions() {
         Set<String> savedOptions = sharedPreferences.getStringSet("wheel_options", new HashSet<>());
         options = new ArrayList<>(savedOptions);
@@ -355,64 +337,96 @@ public class MainActivity extends AppCompatActivity {
         loadOptions(wheel);
         updateTitle(wheel);
     }
-    private void saveWheels(){
-        try {
-            if(Wheels.parallelStream().anyMatch(wheel -> wheel.Name.equals(CurrentWheel.Name)))
-            {
-                new AlertDialog.Builder(this)
-                        .setTitle("Same title found")
-                        .setMessage("Overwrite?")
-                        .setPositiveButton("OK", (dialog, which) -> {
-                            try {
-                                Wheel wheelToOverWrite = findWheelByName(Wheels,CurrentWheel.Name);
-                                wheelToOverWrite.Options = CurrentWheel.Options;
-                                CurrentWheel = wheelToOverWrite;
-                                wheelSerializer.SaveWheelsToSharedPreferences(Wheels, sharedPreferences);
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            }
-                        })
-                        .show();
-                return;
-            }
-            Wheels.add(CurrentWheel);
-            wheelSerializer.SaveWheelsToSharedPreferences(Wheels, sharedPreferences);
+    private void saveWheels() throws JSONException {
+        // Update title
+        CurrentWheel.Name=titleBar.getText().toString();
+        titleBar.clearFocus();
 
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
+        List<Wheel> wheels = wheelDB.getWheels();
+        if(!wheels.contains(CurrentWheel))
+            {
+                WheelDBResult result = wheelDB.AddWheel(CurrentWheel);
+                if (result == WheelDBResult.ERROR)
+                    throw new RuntimeException("Failed to add wheel to DB");
+            }
+        wheelSerializer.SaveWheelsToSharedPreferences(wheels, sharedPreferences);
+
+        // Update menu view
+        prepareWheelMenu();
+
+        Toast.makeText(MainActivity.this,"Wheels saved",Toast.LENGTH_SHORT).show();
     }
 
-    private void FakeWheels() {
+    private void FakeWheels() throws JSONException {
         List<String> fakeoptions =  Arrays.asList("a","b","c");
         List<String> fakeoptions2 =  Arrays.asList("aa","ba","ca");
-        Wheel wheel = new Wheel("Hello",fakeoptions);
-        Wheels.add(wheel);
-        Wheel wheel2 = new Wheel("ni",fakeoptions2);
-        Wheels.add(wheel2);
-        String json=wheel.Serialize();
+        wheelDB.AddWheelWithNewId("Hi",fakeoptions);
+        wheelDB.AddWheelWithNewId("No",fakeoptions2);
+
+        String json=wheelSerializer.SerializeWheels(wheelDB.getWheels());
     }
 
     private void loadWheels() throws JSONException {
-        List<Wheel> loadedWheels=new ArrayList<>();
-        loadedWheels = (List<Wheel>) wheelSerializer.LoadWheelsFromSharedPreferences(sharedPreferences);
+        List<Wheel> loadedWheels = (List<Wheel>) wheelSerializer.LoadWheelsFromSharedPreferences(sharedPreferences);
+        wheelDB.setWheels(loadedWheels);
+        List<Wheel> wheels=wheelDB.getWheels();
+        if(wheels.isEmpty())
+        {
+            wheelDB.AddWheelWithNewId("Example", Arrays.asList("a","b","c"));
+        }
+        CurrentWheel=wheels.get(0);
+        updateWheel(CurrentWheel);
     }
 
     private void addWheel() {
         CurrentWheel=new Wheel();
         updateWheel(CurrentWheel);
+        AskForWheelName();
+    }
+    private void AskForWheelName(){
+        // Create an EditText for the dialog input
+        final EditText input = new EditText(MainActivity.this);
+        input.setInputType(InputType.TYPE_CLASS_TEXT);
+
+        // Create a dialog builder
+        AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
+        builder.setTitle("Enter Wheel title");
+        builder.setView(input);
+
+        // Set up the buttons
+        builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+            dialog.dismiss();
+            String title = input.getText().toString();
+            handleTitleInput(title);  // Call a method to handle the input
+        });
+        builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel());
+
+        // Show the dialog
+        builder.show();
+    }
+    // Method to handle the name input
+    private void handleTitleInput(String title) {
+        // Example handling: Show a toast with the entered name
+        Toast.makeText(this, "Title entered: " + title, Toast.LENGTH_SHORT).show();
+        if(CurrentWheel == null)
+            throw new RuntimeException("Current wheel is null, while setting title");
+        CurrentWheel.Name = title;
+        updateTitle(CurrentWheel);
     }
 
     private void deleteWheel() {
-        if(Wheels.contains(CurrentWheel)) {
-            Wheels.remove(CurrentWheel);
 
-            try {
-                wheelSerializer.SaveWheelsToSharedPreferences(Wheels, sharedPreferences);
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
+        wheelDB.RemoveWheel(CurrentWheel);
+
+        try {
+            wheelSerializer.SaveWheelsToSharedPreferences(wheelDB.getWheels(), sharedPreferences);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
         }
+        // Todo think of a way of handling when no wheel is selected.
         addWheel();
+
+        // Update menu view
+        prepareWheelMenu();
     }
 }

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -341,9 +341,7 @@ public class MainActivity extends AppCompatActivity {
         List<Wheel> wheels = wheelDB.getWheels();
         if(!wheels.contains(CurrentWheel))
             {
-                WheelDBResult result = wheelDB.AddWheel(CurrentWheel);
-                if (result == WheelDBResult.ERROR)
-                    throw new RuntimeException("Failed to add wheel to DB");
+                wheelDB.AddWheel(CurrentWheel);
             }
         wheelSerializer.SaveWheelsToSharedPreferences(wheels, sharedPreferences);
 

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -79,6 +79,13 @@ public class MainActivity extends AppCompatActivity {
         try {
             loadWheels();
         } catch (JSONException e) {
+            Toast.makeText(mainLayout.getContext(),"Wheels settings malformed, making hard-reset",Toast.LENGTH_SHORT).show();
+            try {
+                wheelSerializer.SaveWheelsToSharedPreferences(wheelDB.getWheels(),sharedPreferences);
+                loadWheels();
+            } catch (JSONException ex) {
+                throw new RuntimeException(ex);
+            }
             throw new RuntimeException(e);
         }
         prepareWheelMenu();

--- a/app/src/main/java/evil/spin/MainActivity.java
+++ b/app/src/main/java/evil/spin/MainActivity.java
@@ -210,18 +210,14 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        updateTitle();
         updateBackground();
     }
 
-    private void updateTitle() {
-        String title = sharedPreferences.getString("wheel_title", "Spin the Wheel");
-        titleBar.setText(title);
-    }
     private void updateTitle(Wheel wheel) {
         titleBar.setText(wheel.Name);
         titleBar.refreshDrawableState();
     }
+
     private void updateBackground() {
         String background = sharedPreferences.getString("background", "red");
         setBackgroundByName(background);

--- a/app/src/main/java/evil/spin/SettingsActivity.java
+++ b/app/src/main/java/evil/spin/SettingsActivity.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Set;
 
 public class SettingsActivity extends AppCompatActivity {
-    private EditText titleEditText;
     private Spinner colorPaletteSpinner;
     private Spinner backgroundSpinner;
     private SeekBar wheelSpeedSeekBar;
@@ -43,7 +42,6 @@ public class SettingsActivity extends AppCompatActivity {
 
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
-        titleEditText = findViewById(R.id.titleEditText);
         colorPaletteSpinner = findViewById(R.id.colorPaletteSpinner);
         backgroundSpinner = findViewById(R.id.backgroundSpinner);
         wheelSpeedSeekBar = findViewById(R.id.wheelSpeedSeekBar);
@@ -111,7 +109,6 @@ public class SettingsActivity extends AppCompatActivity {
         int wheelSpeed = sharedPreferences.getInt("wheel_speed", 3000);
         int minWheelSpin = sharedPreferences.getInt("min_wheel_spin", 720);
 
-        titleEditText.setText(title);
         colorPaletteSpinner.setSelection(colorPalette.equals("Pastel") ? 1 : 0);
         backgroundSpinner.setSelection(((ArrayAdapter<String>)backgroundSpinner.getAdapter()).getPosition(background));
         wheelSpeedSeekBar.setProgress(wheelSpeed);
@@ -120,7 +117,6 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void saveSettings() {
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString("wheel_title", titleEditText.getText().toString());
         editor.putString("color_palette", colorPaletteSpinner.getSelectedItem().toString());
         editor.putString("background", backgroundSpinner.getSelectedItem().toString());
         editor.putInt("wheel_speed", wheelSpeedSeekBar.getProgress());

--- a/app/src/main/java/evil/spin/Wheel.java
+++ b/app/src/main/java/evil/spin/Wheel.java
@@ -5,24 +5,28 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import kotlin.NotImplementedError;
-
 public class Wheel implements Serializable {
+    public long Id = 0;
     public String Name = "";
     public Collection<String> Options = Collections.emptyList();
-    public Wheel(String name, Collection<String> options)
+
+    public Wheel(long id, String name, Collection<String> options)
     {
+        Id = id;
         Name = name;
         Options = options;
     }
     public Wheel() {}
+
     public String Serialize()
     {
         JSONObject json = new JSONObject();
         try {
+            json.put("Id",Id);
             json.put("Name",Name);
             JSONArray options = new JSONArray(Options);
             json.put("Options",options);
@@ -31,5 +35,4 @@ public class Wheel implements Serializable {
         }
         return json.toString();
     }
-
 }

--- a/app/src/main/java/evil/spin/Wheel.java
+++ b/app/src/main/java/evil/spin/Wheel.java
@@ -1,0 +1,35 @@
+package evil.spin;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+
+import kotlin.NotImplementedError;
+
+public class Wheel implements Serializable {
+    public String Name = "";
+    public Collection<String> Options = Collections.emptyList();
+    public Wheel(String name, Collection<String> options)
+    {
+        Name = name;
+        Options = options;
+    }
+    public Wheel() {}
+    public String Serialize()
+    {
+        JSONObject json = new JSONObject();
+        try {
+            json.put("Name",Name);
+            JSONArray options = new JSONArray(Options);
+            json.put("Options",options);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        return json.toString();
+    }
+
+}

--- a/app/src/main/java/evil/spin/Wheel.java
+++ b/app/src/main/java/evil/spin/Wheel.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 public class Wheel implements Serializable {
     public int Id = 0;
     public String Name = "";
-    public Collection<String> Options = Collections.emptyList();
+    public Collection<String> Options = new ArrayList<>();
 
     public Wheel(int id, String name, Collection<String> options)
     {

--- a/app/src/main/java/evil/spin/Wheel.java
+++ b/app/src/main/java/evil/spin/Wheel.java
@@ -10,11 +10,11 @@ import java.util.Collection;
 import java.util.Collections;
 
 public class Wheel implements Serializable {
-    public long Id = 0;
+    public int Id = 0;
     public String Name = "";
     public Collection<String> Options = Collections.emptyList();
 
-    public Wheel(long id, String name, Collection<String> options)
+    public Wheel(int id, String name, Collection<String> options)
     {
         Id = id;
         Name = name;

--- a/app/src/main/java/evil/spin/WheelDB.java
+++ b/app/src/main/java/evil/spin/WheelDB.java
@@ -34,13 +34,10 @@ public class WheelDB {
         AddWheel(new Wheel(GetNewId(),name,options));
     }
 
-    public WheelDBResult AddWheel(Wheel wheelToAdd)
+    public void AddWheel(Wheel wheelToAdd)
     {
-        if(Wheels.parallelStream().anyMatch(wheel -> wheel.Id == wheelToAdd.Id))
-            return WheelDBResult.ERROR;
-
+        wheelToAdd.Id=GetNewId();
         Wheels.add(wheelToAdd);
-        return WheelDBResult.OK;
     }
     public Wheel getWheelById(int id) throws Exception {
         // Filter wheels with the matching name

--- a/app/src/main/java/evil/spin/WheelDB.java
+++ b/app/src/main/java/evil/spin/WheelDB.java
@@ -1,0 +1,78 @@
+package evil.spin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class WheelDB {
+    public List<Wheel> getWheels() {
+        return Wheels;
+    }
+
+    public void setWheels(List<Wheel> wheels) {
+        Wheels = wheels;
+    }
+
+    private List<Wheel> Wheels = new ArrayList<>();
+
+
+    /**
+     * @return Takes last element of wheel list and adds 1. Deleted wheels will be ignored, as
+     * the amount of wheels to fill is way too large.
+     */
+    public int GetNewId(){
+        if(Wheels.isEmpty()) return 1;
+        Wheel lastWheel = Wheels.get(Wheels.size()-1);
+        if(Integer.MAX_VALUE-lastWheel.Id==1)
+            throw new RuntimeException("Number overflow, you ran out of wheels");
+        return lastWheel.Id+1;
+    }
+
+    public void AddWheelWithNewId(String name, Collection<String> options)
+    {
+        AddWheel(new Wheel(GetNewId(),name,options));
+    }
+
+    public WheelDBResult AddWheel(Wheel wheelToAdd)
+    {
+        if(Wheels.parallelStream().anyMatch(wheel -> wheel.Id == wheelToAdd.Id))
+            return WheelDBResult.ERROR;
+
+        Wheels.add(wheelToAdd);
+        return WheelDBResult.OK;
+    }
+    public Wheel getWheelById(int id) throws Exception {
+        // Filter wheels with the matching name
+        List<Wheel> matchingWheels = Wheels.parallelStream()
+                .filter(wheel -> wheel.Id==id)
+                .collect(Collectors.toList());
+
+        // Throw exception if no matching wheels or more than one matching wheel is found
+        if (matchingWheels.isEmpty()) {
+            return null;
+        } else if (matchingWheels.size() > 1) {
+            throw new Exception("Multiple wheels found with the id: " + id);
+        }
+
+        // Return the single matching wheel
+        return matchingWheels.get(0);
+    }
+    public WheelDBResult RemoveWheel(Wheel wheelToRemove){
+
+            if(getWheels().contains(wheelToRemove)) {
+                Wheels.remove(wheelToRemove);
+                return WheelDBResult.OK;
+            }
+            return WheelDBResult.ERROR;
+    }
+    public boolean IsEmpty(){
+        return Wheels.isEmpty();
+    }
+    public Wheel GetFirst()
+    {
+        if (Wheels.isEmpty())
+            return null;
+        return Wheels.get(0);
+    }
+}

--- a/app/src/main/java/evil/spin/WheelDBResult.java
+++ b/app/src/main/java/evil/spin/WheelDBResult.java
@@ -1,0 +1,7 @@
+package evil.spin;
+
+public enum WheelDBResult
+{
+    OK,
+    ERROR
+}

--- a/app/src/main/java/evil/spin/WheelSerializer.java
+++ b/app/src/main/java/evil/spin/WheelSerializer.java
@@ -9,7 +9,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -59,7 +58,7 @@ public class WheelSerializer implements IWheelSerializer {
         for(int i = 0; i< wheelsJsonArray.length(); i++)
         {
             JSONObject wheelJson = wheelsJsonArray.getJSONObject(i);
-            Wheel wheel = getWheelFromJson(wheelJson);
+            Wheel wheel = getWheelFromJson(wheelJson.toString());
             wheels.add(wheel);
         }
         return wheels;
@@ -67,10 +66,20 @@ public class WheelSerializer implements IWheelSerializer {
 
     @NonNull
     @Override
-    public Wheel getWheelFromJson(JSONObject wheelJson) throws JSONException {
-        String[] options = toStringArray(wheelJson.getJSONArray("Options"));
-        String wheelName = wheelJson.getString("Name");
-        return new Wheel(wheelName, Arrays.asList(options));
+    public Wheel getWheelFromJson(String wheelJson) throws JSONException {
+        if (wheelJson.isEmpty()) throw new JSONException("Empty Json");
+
+        JSONObject jsonObject = new JSONObject(wheelJson);
+        long id = jsonObject.getLong("Id");
+        String name = jsonObject.getString("Name");
+
+        JSONArray optionsArray = jsonObject.getJSONArray("Options");
+        Collection<String> options = new ArrayList<>();
+        for (int i = 0; i < optionsArray.length(); i++) {
+            options.add(optionsArray.getString(i));
+        }
+
+        return new Wheel(id, name, options);
     }
 
     @Override

--- a/app/src/main/java/evil/spin/WheelSerializer.java
+++ b/app/src/main/java/evil/spin/WheelSerializer.java
@@ -45,7 +45,7 @@ public class WheelSerializer implements IWheelSerializer {
 
     @Override
     public Collection<Wheel> DeserializeWheels(String json) throws JSONException {
-
+        if(json.isEmpty()) return new ArrayList<>();
         JSONObject wheelsJson = new JSONObject(json);
 
         JSONArray wheelsJsonArray = wheelsJson.getJSONArray(SharedPreferencesWheelsKey);

--- a/app/src/main/java/evil/spin/WheelSerializer.java
+++ b/app/src/main/java/evil/spin/WheelSerializer.java
@@ -1,0 +1,87 @@
+package evil.spin;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class WheelSerializer implements IWheelSerializer {
+    private final String SharedPreferencesWheelsKey = "Wheels";
+    @Override
+    public String SerializeWheels(Collection<Wheel> wheels) throws JSONException {
+        List<JSONObject> wheelsJsonObj = new ArrayList<>();
+        for(Wheel wheel:wheels)
+        {
+            JSONObject wheelObj =new JSONObject(wheel.Serialize());
+            wheelsJsonObj.add(wheelObj);
+        }
+        JSONArray wheelsJsonArray = new JSONArray(wheelsJsonObj);
+        JSONObject wheelsJson = new JSONObject();
+        wheelsJson.put(SharedPreferencesWheelsKey,wheelsJsonArray);
+        return wheelsJson.toString();
+    }
+
+    @Override
+    public void SaveWheelsToSharedPreferences(Collection<Wheel> wheels, SharedPreferences preferences) throws JSONException {
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putString(SharedPreferencesWheelsKey, SerializeWheels(wheels));
+        editor.apply();
+    }
+
+    @Override
+    public Collection<Wheel> LoadWheelsFromSharedPreferences(SharedPreferences preferences) throws JSONException {
+        String wheelsJson = preferences.getString(SharedPreferencesWheelsKey,"");
+
+        return DeserializeWheels(wheelsJson);
+    }
+
+    @Override
+    public Collection<Wheel> DeserializeWheels(String json) throws JSONException {
+
+        JSONObject wheelsJson = new JSONObject(json);
+
+        JSONArray wheelsJsonArray = wheelsJson.getJSONArray(SharedPreferencesWheelsKey);
+        return getWheelsFromJsonArray(wheelsJsonArray);
+    }
+
+    @NonNull
+    @Override
+    public List<Wheel> getWheelsFromJsonArray(JSONArray wheelsJsonArray) throws JSONException {
+        List<Wheel> wheels = new ArrayList<>();
+        for(int i = 0; i< wheelsJsonArray.length(); i++)
+        {
+            JSONObject wheelJson = wheelsJsonArray.getJSONObject(i);
+            Wheel wheel = getWheelFromJson(wheelJson);
+            wheels.add(wheel);
+        }
+        return wheels;
+    }
+
+    @NonNull
+    @Override
+    public Wheel getWheelFromJson(JSONObject wheelJson) throws JSONException {
+        String[] options = toStringArray(wheelJson.getJSONArray("Options"));
+        String wheelName = wheelJson.getString("Name");
+        return new Wheel(wheelName, Arrays.asList(options));
+    }
+
+    @Override
+    public String[] toStringArray(JSONArray array) {
+        if(array==null)
+            return new String[0];
+
+        String[] arr=new String[array.length()];
+        for(int i=0; i<arr.length; i++) {
+            arr[i]=array.optString(i);
+        }
+        return arr;
+    }
+}

--- a/app/src/main/java/evil/spin/WheelSerializer.java
+++ b/app/src/main/java/evil/spin/WheelSerializer.java
@@ -70,7 +70,7 @@ public class WheelSerializer implements IWheelSerializer {
         if (wheelJson.isEmpty()) throw new JSONException("Empty Json");
 
         JSONObject jsonObject = new JSONObject(wheelJson);
-        long id = jsonObject.getLong("Id");
+        int id = jsonObject.getInt("Id");
         String name = jsonObject.getString("Name");
 
         JSONArray optionsArray = jsonObject.getJSONArray("Options");

--- a/app/src/main/res/drawable/ic_add_circle.xml
+++ b/app/src/main/res/drawable/ic_add_circle.xml
@@ -4,9 +4,7 @@
     android:tint="#000000"
     android:viewportWidth="24"
     android:viewportHeight="24">
-      
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M20,15.31L23.31,12 20,8.69V4h-4.69L12,0.69 8.69,4H4v4.69L0.69,12 4,15.31V20h4.69L12,23.31 15.31,20H20v-4.69zM12,18c-3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6 6,2.69 6,6 -2.69,6 -6,6z" />
-    
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zm1,15h-2v-4H7v-2h4V7h2v4h4v2h-4v4z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,9v10H8V9h8m-1.5,-6h-5l-1,1H5v2h14V4h-3.5l-1,-1zM18,7H6v12c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_save.xml
+++ b/app/src/main/res/drawable/ic_save.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,21H5c-1.1,0 -2,-0.9 -2,-2V5c0,-1.1 0.9,-2 2,-2h11l5,5v11c0,1.1 -0.9,2 -2,2zM19,8h-4c-0.55,0 -1,-0.45 -1,-1V3.5L19,8zM12,19c1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3 1.34,3 3,3zM6,9h9v2H6V9z"/>
+</vector>

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -12,41 +12,44 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@drawable/screen_red">
+
             <EditText
                 android:id="@+id/titlebar"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_marginBottom="1dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
                 android:fontFamily="monospace"
                 android:gravity="center"
+                android:hint="Wheel Title"
+                android:inputType="text"
+                android:minWidth="150dp"
+                android:minHeight="32dp"
                 android:padding="10dp"
                 android:text="Title"
-                android:hint="Wheel Title"
                 android:textColor="#FFFFFF"
                 android:textStyle="bold"
                 app:autoSizeMaxTextSize="30sp"
                 app:autoSizeMinTextSize="10sp"
                 app:autoSizeStepGranularity="1sp"
                 app:autoSizeTextType="uniform"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHeight_percent="0.067"
-                app:layout_constraintStart_toStartOf="@id/settingsButtonLayout"
-                app:layout_constraintTop_toBottomOf="@id/settingsButtonLayout"
-                android:inputType="text"/>
+                app:layout_constraintBottom_toTopOf="@id/spinButton"
+                app:layout_constraintEnd_toStartOf="@id/settingsButtonLayout"
+                app:layout_constraintStart_toEndOf="@id/wheelView"
+                app:layout_constraintTop_toTopOf="parent" />
 
 
             <LinearLayout
                 android:id="@+id/settingsButtonLayout"
                 style="?android:attr/buttonBarStyle"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="0dp"
                 android:layout_marginEnd="0dp"
                 android:gravity="end"
-                android:orientation="horizontal"
-                android:padding="8dp"
+                android:orientation="vertical"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/addOptionButton">
 
                 <!-- Delete Button -->
                 <com.google.android.material.button.MaterialButton
@@ -76,40 +79,45 @@
 
             <evil.spin.WheelView
                 android:id="@+id/wheelView"
-                android:minWidth="200dp"
-                android:minHeight="200dp"
                 android:layout_width="370dp"
                 android:layout_height="370dp"
-                app:layout_constraintTop_toBottomOf="@id/titlebar"
-                app:layout_constraintBottom_toTopOf="@id/spinButton"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:minWidth="200dp"
+                android:minHeight="200dp"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/spinButton"
+                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/spin"
+                android:layout_marginStart="32dp"
                 android:background="@drawable/normal_buttom_pres"
+                android:text="@string/spin"
+                android:textColor="#FFFFFF"
                 app:backgroundTint="@null"
                 app:cornerRadius="8dp"
-                android:textColor="#FFFFFF"
-                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toTopOf="@id/optionInput"
-                android:layout_marginBottom="16dp" />
+                app:layout_constraintBottom_toTopOf="@+id/optionInput"
+                app:layout_constraintEnd_toEndOf="@id/optionInput"
+                app:layout_constraintStart_toEndOf="@id/wheelView"
+                app:layout_constraintTop_toTopOf="@id/wheelView" />
 
             <EditText
                 android:id="@+id/optionInput"
-                android:layout_width="250dp"
+                android:layout_width="wrap_content"
+                android:minWidth="180dp"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
                 android:hint="@string/it_was_faked"
                 android:inputType="text"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/addOptionButton"
-                android:layout_margin="16dp" />
+                app:layout_constraintStart_toEndOf="@id/wheelView" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/addOptionButton"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,33 +33,54 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHeight_percent="0.067"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/settingsButton" />
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/settingsButton"
-                android:layout_width="70dp"
-                android:layout_height="70dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="8dp"
-                android:padding="0dp"
-                android:contentDescription="no"
-                app:icon="@drawable/bootleg_settings"
-                app:iconGravity="textStart"
-                app:iconPadding="0dp"
-                app:iconSize="60dp"
-                app:iconTint="#FFFFFF"
-                app:cornerRadius="8dp"
-                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-                app:backgroundTint="#0072847E"
-                app:rippleColor="#33FFFFFF"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settingsButtonLayout" />
+
+
+            <LinearLayout
+                android:id="@+id/settingsButtonLayout"
+                style="?android:attr/buttonBarStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="0dp"
+                android:layout_marginEnd="0dp"
+                android:gravity="end"
+                android:orientation="horizontal"
+                android:padding="8dp"
                 app:layout_constraintEnd_toEndOf="parent"
-                />
+                app:layout_constraintTop_toTopOf="parent">
+
+                <!-- Delete Button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_delete"
+                    style="@style/SettingsButtonStyle"
+                    app:icon="@drawable/ic_delete" />
+
+                <!-- Save Button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_save"
+                    style="@style/SettingsButtonStyle"
+                    app:icon="@drawable/ic_save" />
+
+                <!-- Add Wheel Button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_add_wheel"
+                    style="@style/SettingsButtonStyle"
+                    android:hint="@string/add_wheel"
+                    app:icon="@drawable/ic_add_circle" />
+
+                <!-- Add Settings Button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/settingsButton"
+                    app:icon="@drawable/bootleg_settings"
+                    style="@style/SettingsButtonStyle"
+                    />
+            </LinearLayout>
 
             <evil.spin.WheelView
                 android:id="@+id/wheelView"
                 android:layout_width="370dp"
                 android:layout_height="370dp"
-                app:layout_constraintTop_toBottomOf="@id/settingsButton"
+                app:layout_constraintTop_toBottomOf="@id/settingsButtonLayout"
                 app:layout_constraintBottom_toTopOf="@id/spinButton"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
@@ -68,7 +89,7 @@
                 android:id="@+id/spinButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Spin"
+                android:text="@string/spin"
                 android:background="@drawable/normal_buttom_pres"
                 app:backgroundTint="@null"
                 app:cornerRadius="8dp"
@@ -81,9 +102,10 @@
 
             <EditText
                 android:id="@+id/optionInput"
-                android:layout_width="48dp"
+                android:layout_width="250dp"
                 android:layout_height="wrap_content"
-                android:hint="it was faked..."
+                android:hint="@string/it_was_faked"
+                android:inputType="text"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/addOptionButton"
@@ -93,7 +115,7 @@
                 android:id="@+id/addOptionButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Add"
+                android:text="@string/add"
                 android:textColor="#FFFFFF"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/screen_red"
@@ -47,15 +48,6 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         />
-
-    <Spinner
-        android:id="@+id/spinner1"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@android:drawable/btn_dropdown"
-        android:spinnerMode="dropdown"/>
 
     <evil.spin.WheelView
         android:id="@+id/wheelView"
@@ -104,6 +96,35 @@
         app:backgroundTint="@null"
         android:layout_margin="16dp" />
 
+    <androidx.drawerlayout.widget.DrawerLayout
+        android:id="@+id/my_drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="128dp"
+            android:gravity="center"
+            android:text="GeeksforGeeks"
+            android:textSize="18sp" />
+    </LinearLayout>
+
+    <!-- this the navigation view which draws and shows the navigation drawer -->
+    <!-- include the menu created in the menu folder -->
+        <com.google.android.material.navigation.NavigationView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="start"
+            app:menu="@menu/wheel_menu" />
+
+</androidx.drawerlayout.widget.DrawerLayout>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,15 +10,6 @@
     >
 
 
-        <!-- this the navigation view which draws and shows the navigation drawer -->
-        <!-- include the menu created in the menu folder -->
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-         />
-
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -48,6 +48,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         />
 
+    <Spinner
+        android:id="@+id/spinner1"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:drawable/btn_dropdown"
+        android:spinnerMode="dropdown"/>
+
     <evil.spin.WheelView
         android:id="@+id/wheelView"
         android:layout_width="370dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.drawerlayout.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -8,123 +8,115 @@
     android:background="@drawable/screen_red"
     android:id="@+id/activity_main"
     >
-    <TextView
-        android:id="@+id/titlebar"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginBottom="1dp"
-        android:fontFamily="monospace"
-        android:gravity="center"
-        android:padding="10dp"
-        android:text="Title"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="30sp"
-        app:autoSizeMinTextSize="10sp"
-        app:autoSizeStepGranularity="1sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toTopOf="@id/wheelView"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.067"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/settingsButton" />
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/settingsButton"
-        android:layout_width="70dp"
-        android:layout_height="70dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:padding="0dp"
-        android:contentDescription="no"
-        app:icon="@drawable/bootleg_settings"
-        app:iconGravity="textStart"
-        app:iconPadding="0dp"
-        app:iconSize="60dp"
-        app:iconTint="#FFFFFF"
-        app:cornerRadius="8dp"
-        style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-        app:backgroundTint="#0072847E"
-        app:rippleColor="#33FFFFFF"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        />
 
-    <evil.spin.WheelView
-        android:id="@+id/wheelView"
-        android:layout_width="370dp"
-        android:layout_height="370dp"
-        app:layout_constraintTop_toBottomOf="@id/settingsButton"
-        app:layout_constraintBottom_toTopOf="@id/spinButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/spinButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Spin"
-        android:background="@drawable/normal_buttom_pres"
-        app:backgroundTint="@null"
-        app:cornerRadius="8dp"
-        android:textColor="#FFFFFF"
-        style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/optionInput"
-        android:layout_marginBottom="16dp" />
-
-    <EditText
-        android:id="@+id/optionInput"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:hint="it was faked..."
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/addOptionButton"
-        android:layout_margin="16dp" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/addOptionButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Add"
-        android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:background="@drawable/normal_buttom"
-        style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-        app:backgroundTint="@null"
-        android:layout_margin="16dp" />
-
-    <androidx.drawerlayout.widget.DrawerLayout
-        android:id="@+id/my_drawer_layout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity"
-    tools:ignore="HardcodedText">
-
-    <LinearLayout
+        <!-- this the navigation view which draws and shows the navigation drawer -->
+        <!-- include the menu created in the menu folder -->
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+         />
 
-        <TextView
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="128dp"
-            android:gravity="center"
-            android:text="GeeksforGeeks"
-            android:textSize="18sp" />
-    </LinearLayout>
-
-    <!-- this the navigation view which draws and shows the navigation drawer -->
-    <!-- include the menu created in the menu folder -->
-        <com.google.android.material.navigation.NavigationView
-            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_gravity="start"
-            app:menu="@menu/wheel_menu" />
+            android:background="@drawable/screen_red">
+            <TextView
+                android:id="@+id/titlebar"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginBottom="1dp"
+                android:fontFamily="monospace"
+                android:gravity="center"
+                android:padding="10dp"
+                android:text="Title"
+                android:textColor="#FFFFFF"
+                android:textStyle="bold"
+                app:autoSizeMaxTextSize="30sp"
+                app:autoSizeMinTextSize="10sp"
+                app:autoSizeStepGranularity="1sp"
+                app:autoSizeTextType="uniform"
+                app:layout_constraintBottom_toTopOf="@id/wheelView"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_percent="0.067"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settingsButton" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/settingsButton"
+                android:layout_width="70dp"
+                android:layout_height="70dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:padding="0dp"
+                android:contentDescription="no"
+                app:icon="@drawable/bootleg_settings"
+                app:iconGravity="textStart"
+                app:iconPadding="0dp"
+                app:iconSize="60dp"
+                app:iconTint="#FFFFFF"
+                app:cornerRadius="8dp"
+                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
+                app:backgroundTint="#0072847E"
+                app:rippleColor="#33FFFFFF"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                />
+
+            <evil.spin.WheelView
+                android:id="@+id/wheelView"
+                android:layout_width="370dp"
+                android:layout_height="370dp"
+                app:layout_constraintTop_toBottomOf="@id/settingsButton"
+                app:layout_constraintBottom_toTopOf="@id/spinButton"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/spinButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Spin"
+                android:background="@drawable/normal_buttom_pres"
+                app:backgroundTint="@null"
+                app:cornerRadius="8dp"
+                android:textColor="#FFFFFF"
+                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/optionInput"
+                android:layout_marginBottom="16dp" />
+
+            <EditText
+                android:id="@+id/optionInput"
+                android:layout_width="48dp"
+                android:layout_height="wrap_content"
+                android:hint="it was faked..."
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/addOptionButton"
+                android:layout_margin="16dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/addOptionButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Add"
+                android:textColor="#FFFFFF"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:background="@drawable/normal_buttom"
+                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
+                app:backgroundTint="@null"
+                android:layout_margin="16dp" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.navigation.NavigationView
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:id="@+id/navigationView"
+        app:menu="@menu/wheel_menu" />
 
 </androidx.drawerlayout.widget.DrawerLayout>
-
-
-</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@drawable/screen_red">
-            <TextView
+            <EditText
                 android:id="@+id/titlebar"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
@@ -23,6 +23,7 @@
                 android:gravity="center"
                 android:padding="10dp"
                 android:text="Title"
+                android:hint="Wheel Title"
                 android:textColor="#FFFFFF"
                 android:textStyle="bold"
                 app:autoSizeMaxTextSize="30sp"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -12,31 +12,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="16dp">
-        <TextView
-            android:id="@+id/titleLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Wheel Title"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
 
-        <EditText
-            android:id="@+id/titleEditText"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:inputType="text"
-            app:layout_constraintTop_toBottomOf="@id/titleLabel"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="8dp" />
         <TextView
             android:id="@+id/colorPaletteLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:text="Color Palette"
-            app:layout_constraintTop_toBottomOf="@id/titleEditText"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginTop="16dp" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <Spinner
             android:id="@+id/colorPaletteSpinner"

--- a/app/src/main/res/menu/wheel_menu.xml
+++ b/app/src/main/res/menu/wheel_menu.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="HardcodedText">
+
+    <item
+        android:id="@+id/nav_account"
+        android:title="My Account" />
+
+    <item
+        android:id="@+id/nav_settings"
+        android:title="Settings" />
+
+    <item
+        android:id="@+id/nav_logout"
+        android:title="Logout" />
+
+</menu>

--- a/app/src/main/res/menu/wheel_menu.xml
+++ b/app/src/main/res/menu/wheel_menu.xml
@@ -5,7 +5,9 @@
 
     <item
         android:id="@+id/nav_account"
-        android:title="My Account" />
+        android:actionLayout="@layout/activity_main"
+        android:title="My Account"
+        />
 
     <item
         android:id="@+id/nav_settings"

--- a/app/src/main/res/menu/wheel_menu.xml
+++ b/app/src/main/res/menu/wheel_menu.xml
@@ -2,19 +2,9 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="HardcodedText">
-
     <item
-        android:id="@+id/nav_account"
+        android:id="@+id/menu_placeholder"
         android:actionLayout="@layout/activity_main"
-        android:title="My Account"
-        />
-
-    <item
-        android:id="@+id/nav_settings"
-        android:title="Settings" />
-
-    <item
-        android:id="@+id/nav_logout"
-        android:title="Logout" />
-
+        android:title="Placeholder"
+        android:visible="false"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,6 @@
         libero vel nunc consequat, quis tincidunt nisl eleifend. Cras bibendum enim a justo luctus
         vestibulum. Fusce dictum libero quis erat maximus, vitae volutpat diam dignissim.
     </string>
+    <string name="nav_open">Open</string>
+    <string name="nav_close">Close</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,8 @@
     </string>
     <string name="nav_open">Open</string>
     <string name="nav_close">Close</string>
+    <string name="spin">Spin</string>
+    <string name="add_wheel">Add Wheel</string>
+    <string name="add">Add</string>
+    <string name="it_was_faked">it was faked...</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="SettingsButtonStyle" parent="Widget.MaterialComponents.Button">
+        <item name="android:layout_width">70dp</item>
+        <item name="android:layout_height">70dp</item>
+        <item name="android:layout_marginTop">8dp</item>
+        <item name="android:layout_marginEnd">8dp</item>
+        <item name="android:padding">0dp</item>
+
+        <item name="iconGravity">textStart</item>
+        <item name="iconPadding">0dp</item>
+        <item name="iconSize">60dp</item>
+        <item name="iconTint">#FFFFFF</item>
+        <item name="cornerRadius">8dp</item>
+        <item name="backgroundTint">#0072847E</item>
+        <item name="rippleColor">#33FFFFFF</item>
+
+
+
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,7 +11,7 @@
 
         <item name="iconGravity">textStart</item>
         <item name="iconPadding">0dp</item>
-        <item name="iconSize">60dp</item>
+        <item name="iconSize">50dp</item>
         <item name="iconTint">#FFFFFF</item>
         <item name="cornerRadius">8dp</item>
         <item name="backgroundTint">#0072847E</item>


### PR DESCRIPTION
Had to do quite a bit of implementation, but i managed to get it working. It basically uses shared preferences to save a Json with wheel db. Each wheel has its ID to differentiate not just by name and options. 

To do that I also had to add more settings buttons :
![paveikslas](https://github.com/user-attachments/assets/159fa9b4-a4b8-492e-a50f-915713ae0c9a)
Which delete current wheel, save all wheels and adds new wheel. Adding new wheel prompts for a name, but you can also just leave it blank.

To see your loaded wheels you can use a drawer on the left:
![paveikslas](https://github.com/user-attachments/assets/42f96ae0-3000-4c80-9258-5bb33225bf80)
I am not sure how well it will be with other gesture controls. Personally I have disabled side gestures for android OS. 

Each new wheel gets assigned a new id.

I kept the Wheel view untouched as it is working.

@Eve-146T can you look around and see how it feels for you? 

- [ ] Export wheels
- [ ] Import wheels
- [ ] Reset wheel
- [ ] Edit each slice? Could be difficult when wheel becomes large. 
- [ ] Refactor for cleaner code. The main activity is far too crowded, and maybe it is a point where dependency injection could be used, and unit test be written.